### PR TITLE
Fix: CommandService의 일부 return 값을 entity가 아닌 dto로 변경

### DIFF
--- a/src/main/java/shop/yesaladin/shop/member/controller/CommandMemberController.java
+++ b/src/main/java/shop/yesaladin/shop/member/controller/CommandMemberController.java
@@ -9,13 +9,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import shop.yesaladin.shop.member.domain.model.Member;
 import shop.yesaladin.shop.member.dto.MemberCreateRequest;
 import shop.yesaladin.shop.member.dto.MemberCreateResponse;
 import shop.yesaladin.shop.member.service.inter.CommandMemberService;
 
 /**
- * 회원에 관련한 RestController 입니다.
+ * 회원에 관련된 RestController 입니다.
  *
  * @author : 송학현
  * @since : 1.0
@@ -23,7 +22,7 @@ import shop.yesaladin.shop.member.service.inter.CommandMemberService;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/v1/members")
-public class MemberController {
+public class CommandMemberController {
 
     private final CommandMemberService commandMemberService;
 
@@ -38,9 +37,8 @@ public class MemberController {
     @PostMapping
     public ResponseEntity signUpMember(@Valid @RequestBody MemberCreateRequest createDto)
             throws URISyntaxException {
-        Member member = commandMemberService.create(createDto);
-        MemberCreateResponse response = MemberCreateResponse.fromEntity(member);
+        MemberCreateResponse response = commandMemberService.create(createDto);
 
-        return ResponseEntity.created(new URI(member.getId().toString())).body(response);
+        return ResponseEntity.created(new URI(response.getId().toString())).body(response);
     }
 }

--- a/src/main/java/shop/yesaladin/shop/member/domain/model/MemberRole.java
+++ b/src/main/java/shop/yesaladin/shop/member/domain/model/MemberRole.java
@@ -35,7 +35,7 @@ public class MemberRole {
 
     @MapsId("memberId")
     @ManyToOne
-    @JoinColumn(name = "member_Id", nullable = false, unique = true)
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;
 
     @MapsId("roleId")

--- a/src/main/java/shop/yesaladin/shop/member/dto/MemberCreateResponse.java
+++ b/src/main/java/shop/yesaladin/shop/member/dto/MemberCreateResponse.java
@@ -17,6 +17,7 @@ import shop.yesaladin.shop.member.domain.model.MemberGrade;
 @AllArgsConstructor
 public class MemberCreateResponse {
 
+    private Long id;
     private String name;
     private String nickname;
     private String loginId;
@@ -32,6 +33,7 @@ public class MemberCreateResponse {
      */
     public static MemberCreateResponse fromEntity(Member member) {
         return new MemberCreateResponse(
+                member.getId(),
                 member.getName(),
                 member.getNickname(),
                 member.getLoginId(),

--- a/src/main/java/shop/yesaladin/shop/member/service/impl/CommandMemberServiceImpl.java
+++ b/src/main/java/shop/yesaladin/shop/member/service/impl/CommandMemberServiceImpl.java
@@ -9,6 +9,7 @@ import shop.yesaladin.shop.member.domain.model.MemberGrade;
 import shop.yesaladin.shop.member.domain.repository.CommandMemberRepository;
 import shop.yesaladin.shop.member.domain.repository.QueryMemberRepository;
 import shop.yesaladin.shop.member.dto.MemberCreateRequest;
+import shop.yesaladin.shop.member.dto.MemberCreateResponse;
 import shop.yesaladin.shop.member.exception.MemberProfileAlreadyExistException;
 import shop.yesaladin.shop.member.service.inter.CommandMemberService;
 import shop.yesaladin.shop.member.service.inter.QueryMemberGradeService;
@@ -33,13 +34,13 @@ public class CommandMemberServiceImpl implements CommandMemberService {
      * 회원 등록을 위한 기능 입니다.
      *
      * @param createDto 회원 등록 요청 dto
-     * @return 등록된 회원
+     * @return 등록된 회원 결과 dto
      * @author : 송학현
      * @since : 1.0
      */
     @Transactional
     @Override
-    public Member create(MemberCreateRequest createDto) {
+    public MemberCreateResponse create(MemberCreateRequest createDto) {
         checkUniqueData(queryMemberRepository.findMemberByLoginId(createDto.getLoginId()), "id");
         checkUniqueData(
                 queryMemberRepository.findMemberByNickname(createDto.getNickname()),
@@ -47,10 +48,10 @@ public class CommandMemberServiceImpl implements CommandMemberService {
         );
 
         MemberGrade memberGrade = queryMemberGradeService.findById(WHITE_GRADE_ID);
-
         Member member = createDto.toEntity(memberGrade);
+        Member savedMember = commandMemberRepository.save(member);
 
-        return commandMemberRepository.save(member);
+        return MemberCreateResponse.fromEntity(savedMember);
     }
 
     private void checkUniqueData(Optional<Member> member, String target) {

--- a/src/main/java/shop/yesaladin/shop/member/service/impl/QueryMemberGradeServiceImpl.java
+++ b/src/main/java/shop/yesaladin/shop/member/service/impl/QueryMemberGradeServiceImpl.java
@@ -31,6 +31,7 @@ public class QueryMemberGradeServiceImpl implements QueryMemberGradeService {
     @Transactional(readOnly = true)
     @Override
     public MemberGrade findById(int id) {
-        return queryMemberGradeRepository.findById(id).orElseThrow(() -> new MemberGradeNotFoundException(id));
+        return queryMemberGradeRepository.findById(id)
+                .orElseThrow(() -> new MemberGradeNotFoundException(id));
     }
 }

--- a/src/main/java/shop/yesaladin/shop/member/service/impl/QueryMemberServiceImpl.java
+++ b/src/main/java/shop/yesaladin/shop/member/service/impl/QueryMemberServiceImpl.java
@@ -25,6 +25,8 @@ public class QueryMemberServiceImpl implements QueryMemberService {
      *
      * @param id member의 primary key
      * @return 회원 조회 결과
+     * @author : 송학현
+     * @since : 1.0
      */
     @Transactional(readOnly = true)
     @Override
@@ -59,6 +61,7 @@ public class QueryMemberServiceImpl implements QueryMemberService {
     @Transactional(readOnly = true)
     @Override
     public Member findMemberByNickname(String nickname) {
-        return queryMemberRepository.findMemberByNickname(nickname).orElseThrow(() -> new MemberNotFoundException("Member Nickname: " + nickname));
+        return queryMemberRepository.findMemberByNickname(nickname)
+                .orElseThrow(() -> new MemberNotFoundException("Member Nickname: " + nickname));
     }
 }

--- a/src/main/java/shop/yesaladin/shop/member/service/inter/CommandMemberService.java
+++ b/src/main/java/shop/yesaladin/shop/member/service/inter/CommandMemberService.java
@@ -1,7 +1,7 @@
 package shop.yesaladin.shop.member.service.inter;
 
-import shop.yesaladin.shop.member.domain.model.Member;
 import shop.yesaladin.shop.member.dto.MemberCreateRequest;
+import shop.yesaladin.shop.member.dto.MemberCreateResponse;
 
 /**
  * Create, Update, Delete 를 Controller Layer에서 사용하기 위한 service interface
@@ -11,5 +11,13 @@ import shop.yesaladin.shop.member.dto.MemberCreateRequest;
  */
 public interface CommandMemberService {
 
-    Member create(MemberCreateRequest createDto);
+    /**
+     * 회원을 등록하기 위한 기능 입니다.
+     *
+     * @param createDto 회원 등록 요청 dto
+     * @return 회원 등록 결과를 반환할 dto
+     * @author : 송학현
+     * @since : 1.0
+     */
+    MemberCreateResponse create(MemberCreateRequest createDto);
 }

--- a/src/main/java/shop/yesaladin/shop/member/service/inter/QueryMemberGradeService.java
+++ b/src/main/java/shop/yesaladin/shop/member/service/inter/QueryMemberGradeService.java
@@ -10,5 +10,13 @@ import shop.yesaladin.shop.member.domain.model.MemberGrade;
  */
 public interface QueryMemberGradeService {
 
+    /**
+     * 회원 등급을 조회 하기 위한 메서드 입니다.
+     *
+     * @param id 회원 등급의 primary key
+     * @return 회원의 등급 조회 결과
+     * @author : 송학현
+     * @since : 1.0
+     */
     MemberGrade findById(int id);
 }

--- a/src/main/java/shop/yesaladin/shop/member/service/inter/QueryMemberService.java
+++ b/src/main/java/shop/yesaladin/shop/member/service/inter/QueryMemberService.java
@@ -11,9 +11,33 @@ import shop.yesaladin.shop.member.domain.model.Member;
  */
 public interface QueryMemberService {
 
+    /**
+     * 회원을 primary key로 조회 하기 위한 메서드 입니다.
+     *
+     * @param id member의 primary key
+     * @return 회원 조회 결과
+     * @author : 송학현
+     * @since : 1.0
+     */
     Member findMemberById(long id);
 
+    /**
+     * 회원을 unique column인 loginId를 기준 으로 조회 하기 위한 메서드 입니다.
+     *
+     * @param loginId member의 loginId
+     * @return 회원 조회 결과
+     * @author : 송학현
+     * @since : 1.0
+     */
     Member findMemberByLoginId(String loginId);
 
+    /**
+     * 회원을 unique column인 nickname을 기준 으로 조회 하기 위한 메서드 입니다.
+     *
+     * @param nickname member의 nickname
+     * @return 회원 조회 결과
+     * @author : 송학현
+     * @since : 1.0
+     */
     Member findMemberByNickname(String nickname);
 }

--- a/src/test/java/shop/yesaladin/shop/member/controller/CommandMemberControllerTest.java
+++ b/src/test/java/shop/yesaladin/shop/member/controller/CommandMemberControllerTest.java
@@ -24,10 +24,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import shop.yesaladin.shop.member.domain.model.Member;
 import shop.yesaladin.shop.member.dto.MemberCreateRequest;
+import shop.yesaladin.shop.member.dto.MemberCreateResponse;
 import shop.yesaladin.shop.member.service.inter.CommandMemberService;
 
-@WebMvcTest(MemberController.class)
-class MemberControllerTest {
+@WebMvcTest(CommandMemberController.class)
+class CommandMemberControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -39,6 +40,7 @@ class MemberControllerTest {
     private CommandMemberService commandMemberService;
 
     private Member member;
+    private MemberCreateResponse response;
 
     private final String NAME = "Ramos";
     private final String NICKNAME = "Ramos";
@@ -53,6 +55,7 @@ class MemberControllerTest {
     void setUp() {
         long id = 1L;
         member = Member.builder().id(id).name(NAME).nickname(NICKNAME).loginId(LOGIN_ID).build();
+        response = MemberCreateResponse.fromEntity(member);
     }
 
     @Test
@@ -60,7 +63,7 @@ class MemberControllerTest {
     void signUpMember_withInvalidInputData() throws Exception {
         //given
         MemberCreateRequest request = new MemberCreateRequest();
-        given(commandMemberService.create(any())).willReturn(member);
+        given(commandMemberService.create(any())).willReturn(response);
 
         //when
         ResultActions perform = mockMvc.perform(post("/v1/members").contentType(MediaType.APPLICATION_JSON)
@@ -85,7 +88,7 @@ class MemberControllerTest {
                 EMAIL,
                 GENDER
         );
-        given(commandMemberService.create(any())).willReturn(member);
+        given(commandMemberService.create(any())).willReturn(response);
 
         //when
         ResultActions perform = mockMvc.perform(post("/v1/members").contentType(MediaType.APPLICATION_JSON)
@@ -112,7 +115,7 @@ class MemberControllerTest {
         );
         Member member = request.toEntity(null);
 
-        given(commandMemberService.create(any())).willReturn(this.member);
+        given(commandMemberService.create(any())).willReturn(response);
 
         //when
         ResultActions perform = mockMvc.perform(post("/v1/members").contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/shop/yesaladin/shop/member/service/impl/CommandMemberServiceImplTest.java
+++ b/src/test/java/shop/yesaladin/shop/member/service/impl/CommandMemberServiceImplTest.java
@@ -10,6 +10,7 @@ import shop.yesaladin.shop.member.domain.model.MemberGrade;
 import shop.yesaladin.shop.member.domain.repository.CommandMemberRepository;
 import shop.yesaladin.shop.member.domain.repository.QueryMemberRepository;
 import shop.yesaladin.shop.member.dto.MemberCreateRequest;
+import shop.yesaladin.shop.member.dto.MemberCreateResponse;
 import shop.yesaladin.shop.member.service.inter.QueryMemberGradeService;
 
 class CommandMemberServiceImplTest {
@@ -55,7 +56,7 @@ class CommandMemberServiceImplTest {
         Mockito.when(commandMemberRepository.save(member)).thenReturn(member);
 
         //when
-        Member actualMember = service.create(createDto);
+        MemberCreateResponse actualMember = service.create(createDto);
 
         //then
         assertThat(actualMember.getLoginId()).isEqualTo(loginId);


### PR DESCRIPTION
## 다음 issue를 참고해주세요
https://github.com/NHN-YesAladin/yesaladin_shop/issues/68

- QueryService의 경우 상품쪽 service layer에서 사용하고 있거나 member 자체에서도 service layer에서만 사용하고 있기 때문에 변경하지 않았습니다.
- 추 후 QueryController와 같이 추가 될 때 이에 대해 기존 메소드들을 유지하며 dto 리턴 메소드를 추가로 만들 계획입니다.