### PR TITLE
Fix: 컨트롤러 반환값을 ResponseDto로 수정, 상품 검색 조건에 is_deleted = false 추가

### DIFF
--- a/src/main/java/shop/yesaladin/shop/category/dto/SearchCategoryRequestDto.java
+++ b/src/main/java/shop/yesaladin/shop/category/dto/SearchCategoryRequestDto.java
@@ -2,14 +2,13 @@ package shop.yesaladin.shop.category.dto;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class SearchCategoryRequestDto {
-    @NotBlank
+
     String name;
 
     @Min(value = 0)

--- a/src/main/java/shop/yesaladin/shop/product/controller/SearchProductController.java
+++ b/src/main/java/shop/yesaladin/shop/product/controller/SearchProductController.java
@@ -2,8 +2,10 @@ package shop.yesaladin.shop.product.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import shop.yesaladin.common.dto.ResponseDto;
 import shop.yesaladin.shop.product.dto.SearchProductPageRequestDto;
 import shop.yesaladin.shop.product.dto.SearchedProductManagerResponseDto;
 import shop.yesaladin.shop.product.dto.SearchedProductResponseDto;
@@ -35,16 +37,18 @@ public class SearchProductController {
      * @since : 1.0
      */
     @GetMapping(params = "title")
-    public ResponseEntity<SearchedProductResponseDto> searchProductByTitle(
+    public ResponseDto<SearchedProductResponseDto> searchProductByTitle(
             @RequestParam String title,
             @ModelAttribute @Valid SearchProductPageRequestDto pageRequest
     ) {
-        log.info(title);
-        return ResponseEntity.ok(searchProductService.searchProductsByProductTitle(
-                title,
-                pageRequest.getOffset(),
-                pageRequest.getSize()
-        ));
+        return ResponseDto.<SearchedProductResponseDto>builder()
+                .success(true)
+                .data(searchProductService.searchProductsByProductTitle(title,
+                        pageRequest.getOffset(),
+                        pageRequest.getSize()
+                ))
+                .status(HttpStatus.OK)
+                .build();
     }
 
     /**
@@ -57,14 +61,18 @@ public class SearchProductController {
      * @since : 1.0
      */
     @GetMapping(params = "content")
-    public ResponseEntity<SearchedProductResponseDto> searchProductByContent(
+    public ResponseDto<SearchedProductResponseDto> searchProductByContent(
             @RequestParam String content,
             @ModelAttribute @Valid SearchProductPageRequestDto pageRequest
     ) {
-        return ResponseEntity.ok(searchProductService.searchProductsByProductContent(content,
-                pageRequest.getOffset(),
-                pageRequest.getSize()
-        ));
+        return ResponseDto.<SearchedProductResponseDto>builder()
+                .success(true)
+                .data(searchProductService.searchProductsByProductContent(content,
+                        pageRequest.getOffset(),
+                        pageRequest.getSize()
+                ))
+                .status(HttpStatus.OK)
+                .build();
     }
 
     /**
@@ -77,14 +85,18 @@ public class SearchProductController {
      * @since : 1.0
      */
     @GetMapping(params = "isbn")
-    public ResponseEntity<SearchedProductResponseDto> searchProductByISBN(
+    public ResponseDto<SearchedProductResponseDto> searchProductByISBN(
             @RequestParam String isbn,
             @ModelAttribute @Valid SearchProductPageRequestDto pageRequest
     ) {
-        return ResponseEntity.ok(searchProductService.searchProductsByProductISBN(isbn,
-                pageRequest.getOffset(),
-                pageRequest.getSize()
-        ));
+        return ResponseDto.<SearchedProductResponseDto>builder()
+                .success(true)
+                .data(searchProductService.searchProductsByProductISBN(isbn,
+                        pageRequest.getOffset(),
+                        pageRequest.getSize()
+                ))
+                .status(HttpStatus.OK)
+                .build();
     }
 
     /**
@@ -97,14 +109,18 @@ public class SearchProductController {
      * @since : 1.0
      */
     @GetMapping(params = "author")
-    public ResponseEntity<SearchedProductResponseDto> searchProductByAuthor(
+    public ResponseDto<SearchedProductResponseDto> searchProductByAuthor(
             @RequestParam String author,
             @ModelAttribute @Valid SearchProductPageRequestDto pageRequest
     ) {
-        return ResponseEntity.ok(searchProductService.searchProductsByProductAuthor(author,
-                pageRequest.getOffset(),
-                pageRequest.getSize()
-        ));
+        return ResponseDto.<SearchedProductResponseDto>builder()
+                .success(true)
+                .data(searchProductService.searchProductsByProductAuthor(author,
+                        pageRequest.getOffset(),
+                        pageRequest.getSize()
+                ))
+                .status(HttpStatus.OK)
+                .build();
     }
 
     /**
@@ -117,14 +133,18 @@ public class SearchProductController {
      * @since : 1.0
      */
     @GetMapping(params = "publisher")
-    public ResponseEntity<SearchedProductResponseDto> searchProductByPublisher(
+    public ResponseDto<SearchedProductResponseDto> searchProductByPublisher(
             @RequestParam String publisher,
             @ModelAttribute @Valid SearchProductPageRequestDto pageRequest
     ) {
-        return ResponseEntity.ok(searchProductService.searchProductsByPublisher(publisher,
-                pageRequest.getOffset(),
-                pageRequest.getSize()
-        ));
+        return ResponseDto.<SearchedProductResponseDto>builder()
+                .success(true)
+                .data(searchProductService.searchProductsByPublisher(publisher,
+                        pageRequest.getOffset(),
+                        pageRequest.getSize()
+                ))
+                .status(HttpStatus.OK)
+                .build();
     }
 
     /**
@@ -137,14 +157,18 @@ public class SearchProductController {
      * @since : 1.0
      */
     @GetMapping(params = "tag")
-    public ResponseEntity<SearchedProductResponseDto> searchProductByTag(
+    public ResponseDto<SearchedProductResponseDto> searchProductByTag(
             @RequestParam String tag,
             @ModelAttribute @Valid SearchProductPageRequestDto pageRequest
     ) {
-        return ResponseEntity.ok(searchProductService.searchProductsByTag(tag,
-                pageRequest.getOffset(),
-                pageRequest.getSize()
-        ));
+        return ResponseDto.<SearchedProductResponseDto>builder()
+                .success(true)
+                .data(searchProductService.searchProductsByTag(tag,
+                        pageRequest.getOffset(),
+                        pageRequest.getSize()
+                ))
+                .status(HttpStatus.OK)
+                .build();
     }
 
     /**
@@ -157,14 +181,18 @@ public class SearchProductController {
      * @since : 1.0
      */
     @GetMapping(params = "categoryid")
-    public ResponseEntity<SearchedProductManagerResponseDto> searchProductByCategoryId(
+    public ResponseDto<SearchedProductManagerResponseDto> searchProductByCategoryId(
             @RequestParam(name = "categoryid") Long id,
             @ModelAttribute @Valid SearchProductPageRequestDto pageRequest
     ) {
-        return ResponseEntity.ok(searchProductService.searchProductsByCategoryId(id,
-                pageRequest.getOffset(),
-                pageRequest.getSize()
-        ));
+        return ResponseDto.<SearchedProductManagerResponseDto>builder()
+                .success(true)
+                .data(searchProductService.searchProductsByCategoryId(id,
+                        pageRequest.getOffset(),
+                        pageRequest.getSize()
+                ))
+                .status(HttpStatus.OK)
+                .build();
     }
 
     /**
@@ -177,13 +205,17 @@ public class SearchProductController {
      * @since : 1.0
      */
     @GetMapping(params = "categoryname")
-    public ResponseEntity<SearchedProductManagerResponseDto> searchProductByCategoryName(
+    public ResponseDto<SearchedProductManagerResponseDto> searchProductByCategoryName(
             @RequestParam(name = "categoryname") String name,
             @ModelAttribute @Valid SearchProductPageRequestDto pageRequest
     ) {
-        return ResponseEntity.ok(searchProductService.searchProductsByCategoryName(name,
-                pageRequest.getOffset(),
-                pageRequest.getSize()
-        ));
+        return ResponseDto.<SearchedProductManagerResponseDto>builder()
+                .success(true)
+                .data(searchProductService.searchProductsByCategoryName(name,
+                        pageRequest.getOffset(),
+                        pageRequest.getSize()
+                ))
+                .status(HttpStatus.OK)
+                .build();
     }
 }

--- a/src/main/java/shop/yesaladin/shop/product/domain/model/SearchedProduct.java
+++ b/src/main/java/shop/yesaladin/shop/product/domain/model/SearchedProduct.java
@@ -68,6 +68,8 @@ public class SearchedProduct {
     private LocalDate publishedDate;
     @Field(name = "saving_method", type = FieldType.Keyword)
     private String savingMethod;
+    @Field(name = "is_deleted", type = FieldType.Boolean)
+    private Boolean isDeleted;
     @Field(name = "categories", type = FieldType.Object)
     private List<SearchedProductCategory> categories;
     @Field(name = "authors", type = FieldType.Object)

--- a/src/main/java/shop/yesaladin/shop/product/domain/model/SearchedProduct.java
+++ b/src/main/java/shop/yesaladin/shop/product/domain/model/SearchedProduct.java
@@ -50,8 +50,8 @@ public class SearchedProduct {
     private boolean isSale;
     @Field(name = "quantity", type = FieldType.Long)
     private Long quantity;
-    @Field(name = "is_forced_out_of_stack", type = FieldType.Boolean)
-    private Boolean isForcedOutOfStack;
+    @Field(name = "is_forced_out_of_stock", type = FieldType.Boolean)
+    private Boolean isForcedOutOfStock;
     @Field(name = "preferential_show_ranking", type = FieldType.Long)
     private long preferentialShowRanking;
     @Field(name = "product_type", type = FieldType.Object)

--- a/src/main/java/shop/yesaladin/shop/product/domain/repository/SearchProductRepository.java
+++ b/src/main/java/shop/yesaladin/shop/product/domain/repository/SearchProductRepository.java
@@ -139,7 +139,7 @@ public interface SearchProductRepository {
      * @author : 김선홍
      * @since : 1.0
      */
-    SearchedProductResponseDto searchProductByMultiQuery(
+    SearchedProductResponseDto searchResponseProductByMultiQuery(
             String value,
             int offset,
             int size,
@@ -157,7 +157,7 @@ public interface SearchProductRepository {
      * @author : 김선홍
      * @since : 1.0
      */
-    SearchedProductResponseDto searchProductByTermQuery(
+    SearchedProductResponseDto searchResponseProductByTermQuery(
             String value,
             int offset,
             int size,

--- a/src/main/java/shop/yesaladin/shop/product/dto/SearchedProductDto.java
+++ b/src/main/java/shop/yesaladin/shop/product/dto/SearchedProductDto.java
@@ -21,7 +21,7 @@ public class SearchedProductDto {
     private Long quantity;
     private int discountRate;
     private long sellingPrice;
-    private Boolean isForcedOutOfStack;
+    private Boolean isForcedOutOfStock;
     private String thumbnailFileUrl;
     private String publisher;
     private String publishedDate;
@@ -44,7 +44,7 @@ public class SearchedProductDto {
                 .thumbnailFileUrl(searchedProduct.getThumbnailFile().getName())
                 .tags(searchedProduct.getTags().stream().map(SearchedProductTag::getName).collect(
                         Collectors.toList()))
-                .isForcedOutOfStack(searchedProduct.getIsForcedOutOfStack())
+                .isForcedOutOfStock(searchedProduct.getIsForcedOutOfStock())
                 .build();
     }
 }

--- a/src/main/java/shop/yesaladin/shop/publish/dto/SearchPublisherRequestDto.java
+++ b/src/main/java/shop/yesaladin/shop/publish/dto/SearchPublisherRequestDto.java
@@ -1,16 +1,13 @@
 package shop.yesaladin.shop.publish.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class SearchPublisherRequestDto {
-    @NotBlank
     String name;
 
     @Min(value = 0)

--- a/src/main/java/shop/yesaladin/shop/tag/dto/SearchTagRequestDto.java
+++ b/src/main/java/shop/yesaladin/shop/tag/dto/SearchTagRequestDto.java
@@ -1,16 +1,13 @@
 package shop.yesaladin.shop.tag.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class SearchTagRequestDto {
-    @NotBlank
     String name;
     @Min(value = 0)
     int offset;

--- a/src/main/java/shop/yesaladin/shop/writing/dto/SearchAuthorRequestDto.java
+++ b/src/main/java/shop/yesaladin/shop/writing/dto/SearchAuthorRequestDto.java
@@ -1,16 +1,13 @@
 package shop.yesaladin.shop.writing.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class SearchAuthorRequestDto {
-    @NotBlank
     String name;
     @Min(value = 0)
     int offset;

--- a/src/test/java/shop/yesaladin/shop/product/controller/SearchProductControllerTest.java
+++ b/src/test/java/shop/yesaladin/shop/product/controller/SearchProductControllerTest.java
@@ -184,23 +184,62 @@ class SearchProductControllerTest {
                 .param("size", ONE));
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.count", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].id", equalTo(INT_MIN)))
-                .andExpect(jsonPath("$.products[0].title", equalTo(dummySearchedProductDto.getTitle())))
-                .andExpect(jsonPath("$.products[0].quantity", equalTo(dummySearchedProductDto.getQuantity())))
-                .andExpect(jsonPath("$.products[0].discountRate", equalTo(dummySearchedProductDto.getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].sellingPrice", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].isForcedOutOfStack", equalTo(dummySearchedProductDto.getIsForcedOutOfStack())))
-                .andExpect(jsonPath("$.products[0].thumbnailFileUrl", equalTo(dummySearchedProductDto.getThumbnailFileUrl())))
-                .andExpect(jsonPath("$.products[0].publisher", equalTo(dummySearchedProductDto.getPublisher())))
-                .andExpect(jsonPath("$.products[0].publishedDate", equalTo(dummySearchedProductDto.getPublishedDate())))
-                .andExpect(jsonPath("$.products[0].categories[0].id", equalTo(12)))
-                .andExpect(jsonPath("$.products[0].categories[0].parent", equalTo(dummySearchedProductDto.getCategories().get(0).getParent())))
-                .andExpect(jsonPath("$.products[0].categories[0].name", equalTo(dummySearchedProductDto.getCategories().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].categories[0].isShown", equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())))
-                .andExpect(jsonPath("$.products[0].categories[0].disable", equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())))
-                .andExpect(jsonPath("$.products[0].authors[0]", equalTo(dummySearchedProductDto.getAuthors().get(0))))
-                .andExpect(jsonPath("$.products[0].tags[0]", equalTo(dummySearchedProductDto.getTags().get(0))))
+                .andExpect(jsonPath("$.data.count", equalTo(INT_ONE)))
+                .andExpect(jsonPath("$.data.products[0].id", equalTo(INT_MIN)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].title",
+                        equalTo(dummySearchedProductDto.getTitle())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].quantity",
+                        equalTo(dummySearchedProductDto.getQuantity())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].discountRate",
+                        equalTo(dummySearchedProductDto.getDiscountRate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isForcedOutOfStack",
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFileUrl",
+                        equalTo(dummySearchedProductDto.getThumbnailFileUrl())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publisher",
+                        equalTo(dummySearchedProductDto.getPublisher())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publishedDate",
+                        equalTo(dummySearchedProductDto.getPublishedDate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].categories[0].id", equalTo(12)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].parent",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getParent())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].name",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].isShown",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].disable",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].authors[0]",
+                        equalTo(dummySearchedProductDto.getAuthors().get(0))
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].tags[0]",
+                        equalTo(dummySearchedProductDto.getTags().get(0))
+                ))
                 .andDo(print());
 
         verify(searchProductService, atLeastOnce()).searchProductsByProductTitle(TITLE, 0, 1);
@@ -276,25 +315,63 @@ class SearchProductControllerTest {
                 .param("size", ONE));
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.count", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].id", equalTo(INT_MIN)))
-                .andExpect(jsonPath("$.products[0].title", equalTo(dummySearchedProductDto.getTitle())))
-                .andExpect(jsonPath("$.products[0].quantity", equalTo(dummySearchedProductDto.getQuantity())))
-                .andExpect(jsonPath("$.products[0].discountRate", equalTo(dummySearchedProductDto.getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].sellingPrice", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].isForcedOutOfStack", equalTo(dummySearchedProductDto.getIsForcedOutOfStack())))
-                .andExpect(jsonPath("$.products[0].thumbnailFileUrl", equalTo(dummySearchedProductDto.getThumbnailFileUrl())))
-                .andExpect(jsonPath("$.products[0].publisher", equalTo(dummySearchedProductDto.getPublisher())))
-                .andExpect(jsonPath("$.products[0].publishedDate", equalTo(dummySearchedProductDto.getPublishedDate())))
-                .andExpect(jsonPath("$.products[0].categories[0].id", equalTo(12)))
-                .andExpect(jsonPath("$.products[0].categories[0].parent", equalTo(dummySearchedProductDto.getCategories().get(0).getParent())))
-                .andExpect(jsonPath("$.products[0].categories[0].name", equalTo(dummySearchedProductDto.getCategories().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].categories[0].isShown", equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())))
-                .andExpect(jsonPath("$.products[0].categories[0].disable", equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())))
-                .andExpect(jsonPath("$.products[0].authors[0]", equalTo(dummySearchedProductDto.getAuthors().get(0))))
-                .andExpect(jsonPath("$.products[0].tags[0]", equalTo(dummySearchedProductDto.getTags().get(0))))
+                .andExpect(jsonPath("$.data.count", equalTo(INT_ONE)))
+                .andExpect(jsonPath("$.data.products[0].id", equalTo(INT_MIN)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].title",
+                        equalTo(dummySearchedProductDto.getTitle())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].quantity",
+                        equalTo(dummySearchedProductDto.getQuantity())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].discountRate",
+                        equalTo(dummySearchedProductDto.getDiscountRate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isForcedOutOfStack",
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFileUrl",
+                        equalTo(dummySearchedProductDto.getThumbnailFileUrl())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publisher",
+                        equalTo(dummySearchedProductDto.getPublisher())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publishedDate",
+                        equalTo(dummySearchedProductDto.getPublishedDate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].categories[0].id", equalTo(12)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].parent",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getParent())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].name",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].isShown",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].disable",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].authors[0]",
+                        equalTo(dummySearchedProductDto.getAuthors().get(0))
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].tags[0]",
+                        equalTo(dummySearchedProductDto.getTags().get(0))
+                ))
                 .andDo(print());
-
 
         verify(searchProductService, atLeastOnce()).searchProductsByProductContent(CONTENT, 0, 1);
     }
@@ -365,25 +442,63 @@ class SearchProductControllerTest {
                 .param("size", ONE));
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.count", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].id", equalTo(INT_MIN)))
-                .andExpect(jsonPath("$.products[0].title", equalTo(dummySearchedProductDto.getTitle())))
-                .andExpect(jsonPath("$.products[0].quantity", equalTo(dummySearchedProductDto.getQuantity())))
-                .andExpect(jsonPath("$.products[0].discountRate", equalTo(dummySearchedProductDto.getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].sellingPrice", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].isForcedOutOfStack", equalTo(dummySearchedProductDto.getIsForcedOutOfStack())))
-                .andExpect(jsonPath("$.products[0].thumbnailFileUrl", equalTo(dummySearchedProductDto.getThumbnailFileUrl())))
-                .andExpect(jsonPath("$.products[0].publisher", equalTo(dummySearchedProductDto.getPublisher())))
-                .andExpect(jsonPath("$.products[0].publishedDate", equalTo(dummySearchedProductDto.getPublishedDate())))
-                .andExpect(jsonPath("$.products[0].categories[0].id", equalTo(12)))
-                .andExpect(jsonPath("$.products[0].categories[0].parent", equalTo(dummySearchedProductDto.getCategories().get(0).getParent())))
-                .andExpect(jsonPath("$.products[0].categories[0].name", equalTo(dummySearchedProductDto.getCategories().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].categories[0].isShown", equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())))
-                .andExpect(jsonPath("$.products[0].categories[0].disable", equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())))
-                .andExpect(jsonPath("$.products[0].authors[0]", equalTo(dummySearchedProductDto.getAuthors().get(0))))
-                .andExpect(jsonPath("$.products[0].tags[0]", equalTo(dummySearchedProductDto.getTags().get(0))))
+                .andExpect(jsonPath("$.data.count", equalTo(INT_ONE)))
+                .andExpect(jsonPath("$.data.products[0].id", equalTo(INT_MIN)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].title",
+                        equalTo(dummySearchedProductDto.getTitle())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].quantity",
+                        equalTo(dummySearchedProductDto.getQuantity())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].discountRate",
+                        equalTo(dummySearchedProductDto.getDiscountRate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isForcedOutOfStack",
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFileUrl",
+                        equalTo(dummySearchedProductDto.getThumbnailFileUrl())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publisher",
+                        equalTo(dummySearchedProductDto.getPublisher())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publishedDate",
+                        equalTo(dummySearchedProductDto.getPublishedDate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].categories[0].id", equalTo(12)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].parent",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getParent())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].name",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].isShown",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].disable",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].authors[0]",
+                        equalTo(dummySearchedProductDto.getAuthors().get(0))
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].tags[0]",
+                        equalTo(dummySearchedProductDto.getTags().get(0))
+                ))
                 .andDo(print());
-
 
         verify(searchProductService, atLeastOnce()).searchProductsByProductISBN(ISBN, 0, 1);
     }
@@ -456,23 +571,62 @@ class SearchProductControllerTest {
                 .param("size", ONE));
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.count", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].id", equalTo(INT_MIN)))
-                .andExpect(jsonPath("$.products[0].title", equalTo(dummySearchedProductDto.getTitle())))
-                .andExpect(jsonPath("$.products[0].quantity", equalTo(dummySearchedProductDto.getQuantity())))
-                .andExpect(jsonPath("$.products[0].discountRate", equalTo(dummySearchedProductDto.getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].sellingPrice", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].isForcedOutOfStack", equalTo(dummySearchedProductDto.getIsForcedOutOfStack())))
-                .andExpect(jsonPath("$.products[0].thumbnailFileUrl", equalTo(dummySearchedProductDto.getThumbnailFileUrl())))
-                .andExpect(jsonPath("$.products[0].publisher", equalTo(dummySearchedProductDto.getPublisher())))
-                .andExpect(jsonPath("$.products[0].publishedDate", equalTo(dummySearchedProductDto.getPublishedDate())))
-                .andExpect(jsonPath("$.products[0].categories[0].id", equalTo(12)))
-                .andExpect(jsonPath("$.products[0].categories[0].parent", equalTo(dummySearchedProductDto.getCategories().get(0).getParent())))
-                .andExpect(jsonPath("$.products[0].categories[0].name", equalTo(dummySearchedProductDto.getCategories().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].categories[0].isShown", equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())))
-                .andExpect(jsonPath("$.products[0].categories[0].disable", equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())))
-                .andExpect(jsonPath("$.products[0].authors[0]", equalTo(dummySearchedProductDto.getAuthors().get(0))))
-                .andExpect(jsonPath("$.products[0].tags[0]", equalTo(dummySearchedProductDto.getTags().get(0))))
+                .andExpect(jsonPath("$.data.count", equalTo(INT_ONE)))
+                .andExpect(jsonPath("$.data.products[0].id", equalTo(INT_MIN)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].title",
+                        equalTo(dummySearchedProductDto.getTitle())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].quantity",
+                        equalTo(dummySearchedProductDto.getQuantity())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].discountRate",
+                        equalTo(dummySearchedProductDto.getDiscountRate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isForcedOutOfStack",
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFileUrl",
+                        equalTo(dummySearchedProductDto.getThumbnailFileUrl())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publisher",
+                        equalTo(dummySearchedProductDto.getPublisher())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publishedDate",
+                        equalTo(dummySearchedProductDto.getPublishedDate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].categories[0].id", equalTo(12)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].parent",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getParent())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].name",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].isShown",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].disable",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].authors[0]",
+                        equalTo(dummySearchedProductDto.getAuthors().get(0))
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].tags[0]",
+                        equalTo(dummySearchedProductDto.getTags().get(0))
+                ))
                 .andDo(print());
     }
 
@@ -550,23 +704,62 @@ class SearchProductControllerTest {
                 .param("size", ONE));
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.count", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].id", equalTo(INT_MIN)))
-                .andExpect(jsonPath("$.products[0].title", equalTo(dummySearchedProductDto.getTitle())))
-                .andExpect(jsonPath("$.products[0].quantity", equalTo(dummySearchedProductDto.getQuantity())))
-                .andExpect(jsonPath("$.products[0].discountRate", equalTo(dummySearchedProductDto.getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].sellingPrice", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].isForcedOutOfStack", equalTo(dummySearchedProductDto.getIsForcedOutOfStack())))
-                .andExpect(jsonPath("$.products[0].thumbnailFileUrl", equalTo(dummySearchedProductDto.getThumbnailFileUrl())))
-                .andExpect(jsonPath("$.products[0].publisher", equalTo(dummySearchedProductDto.getPublisher())))
-                .andExpect(jsonPath("$.products[0].publishedDate", equalTo(dummySearchedProductDto.getPublishedDate())))
-                .andExpect(jsonPath("$.products[0].categories[0].id", equalTo(12)))
-                .andExpect(jsonPath("$.products[0].categories[0].parent", equalTo(dummySearchedProductDto.getCategories().get(0).getParent())))
-                .andExpect(jsonPath("$.products[0].categories[0].name", equalTo(dummySearchedProductDto.getCategories().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].categories[0].isShown", equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())))
-                .andExpect(jsonPath("$.products[0].categories[0].disable", equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())))
-                .andExpect(jsonPath("$.products[0].authors[0]", equalTo(dummySearchedProductDto.getAuthors().get(0))))
-                .andExpect(jsonPath("$.products[0].tags[0]", equalTo(dummySearchedProductDto.getTags().get(0))))
+                .andExpect(jsonPath("$.data.count", equalTo(INT_ONE)))
+                .andExpect(jsonPath("$.data.products[0].id", equalTo(INT_MIN)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].title",
+                        equalTo(dummySearchedProductDto.getTitle())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].quantity",
+                        equalTo(dummySearchedProductDto.getQuantity())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].discountRate",
+                        equalTo(dummySearchedProductDto.getDiscountRate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isForcedOutOfStack",
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFileUrl",
+                        equalTo(dummySearchedProductDto.getThumbnailFileUrl())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publisher",
+                        equalTo(dummySearchedProductDto.getPublisher())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publishedDate",
+                        equalTo(dummySearchedProductDto.getPublishedDate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].categories[0].id", equalTo(12)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].parent",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getParent())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].name",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].isShown",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].disable",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].authors[0]",
+                        equalTo(dummySearchedProductDto.getAuthors().get(0))
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].tags[0]",
+                        equalTo(dummySearchedProductDto.getTags().get(0))
+                ))
                 .andDo(print());
 
         verify(searchProductService, atLeastOnce()).searchProductsByPublisher(PUBLISHER, 0, 1);
@@ -644,23 +837,62 @@ class SearchProductControllerTest {
                 .param("size", ONE));
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.count", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].id", equalTo(INT_MIN)))
-                .andExpect(jsonPath("$.products[0].title", equalTo(dummySearchedProductDto.getTitle())))
-                .andExpect(jsonPath("$.products[0].quantity", equalTo(dummySearchedProductDto.getQuantity())))
-                .andExpect(jsonPath("$.products[0].discountRate", equalTo(dummySearchedProductDto.getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].sellingPrice", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].isForcedOutOfStack", equalTo(dummySearchedProductDto.getIsForcedOutOfStack())))
-                .andExpect(jsonPath("$.products[0].thumbnailFileUrl", equalTo(dummySearchedProductDto.getThumbnailFileUrl())))
-                .andExpect(jsonPath("$.products[0].publisher", equalTo(dummySearchedProductDto.getPublisher())))
-                .andExpect(jsonPath("$.products[0].publishedDate", equalTo(dummySearchedProductDto.getPublishedDate())))
-                .andExpect(jsonPath("$.products[0].categories[0].id", equalTo(12)))
-                .andExpect(jsonPath("$.products[0].categories[0].parent", equalTo(dummySearchedProductDto.getCategories().get(0).getParent())))
-                .andExpect(jsonPath("$.products[0].categories[0].name", equalTo(dummySearchedProductDto.getCategories().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].categories[0].isShown", equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())))
-                .andExpect(jsonPath("$.products[0].categories[0].disable", equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())))
-                .andExpect(jsonPath("$.products[0].authors[0]", equalTo(dummySearchedProductDto.getAuthors().get(0))))
-                .andExpect(jsonPath("$.products[0].tags[0]", equalTo(dummySearchedProductDto.getTags().get(0))))
+                .andExpect(jsonPath("$.data.count", equalTo(INT_ONE)))
+                .andExpect(jsonPath("$.data.products[0].id", equalTo(INT_MIN)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].title",
+                        equalTo(dummySearchedProductDto.getTitle())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].quantity",
+                        equalTo(dummySearchedProductDto.getQuantity())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].discountRate",
+                        equalTo(dummySearchedProductDto.getDiscountRate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isForcedOutOfStack",
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFileUrl",
+                        equalTo(dummySearchedProductDto.getThumbnailFileUrl())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publisher",
+                        equalTo(dummySearchedProductDto.getPublisher())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publishedDate",
+                        equalTo(dummySearchedProductDto.getPublishedDate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].categories[0].id", equalTo(12)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].parent",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getParent())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].name",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].isShown",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getIsShown())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].disable",
+                        equalTo(dummySearchedProductDto.getCategories().get(0).getDisable())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].authors[0]",
+                        equalTo(dummySearchedProductDto.getAuthors().get(0))
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].tags[0]",
+                        equalTo(dummySearchedProductDto.getTags().get(0))
+                ))
                 .andDo(print());
 
         verify(searchProductService, atLeastOnce()).searchProductsByTag(TAG, 0, 1);
@@ -725,7 +957,9 @@ class SearchProductControllerTest {
     @DisplayName("카테고리 id로 검색 성공")
     void testSearchProductByCategoryIdSuccess() throws Exception {
         //given
-        Mockito.when(searchProductService.searchProductsByCategoryId(dummySearchedProductManagerDto.getCategories().get(0).getId(), 0, 1))
+        Mockito.when(searchProductService.searchProductsByCategoryId(dummySearchedProductManagerDto.getCategories()
+                        .get(0)
+                        .getId(), 0, 1))
                 .thenReturn(dummySearchedProductManagerResponseDto);
 
         //when
@@ -737,45 +971,126 @@ class SearchProductControllerTest {
                 .param("size", ONE));
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.count", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].id", equalTo(INT_MIN)))
-                .andExpect(jsonPath("$.products[0].title", equalTo(dummySearchedProductManagerDto.getTitle())))
-                .andExpect(jsonPath("$.products[0].isbn", equalTo(dummySearchedProductManagerDto.getIsbn())))
-                .andExpect(jsonPath("$.products[0].actualPrice", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].discountRate", equalTo(dummySearchedProductManagerDto.getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].separatelyDiscount", equalTo(dummySearchedProductManagerDto.isSeparatelyDiscount())))
-                .andExpect(jsonPath("$.products[0].givenPointRate", equalTo(dummySearchedProductManagerDto.getGivenPointRate())))
-                .andExpect(jsonPath("$.products[0].isGivenPoint", equalTo(dummySearchedProductManagerDto.getIsGivenPoint())))
-                .andExpect(jsonPath("$.products[0].isSale", equalTo(dummySearchedProductManagerDto.getIsSale())))
-                .andExpect(jsonPath("$.products[0].quantity", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].productType.id", equalTo(1)))
-                .andExpect(jsonPath("$.products[0].productType.name", equalTo(dummySearchedProductManagerDto.getProductType().getName())))
-                .andExpect(jsonPath("$.products[0].searchedTotalDiscountRate.id", equalTo(dummySearchedProductManagerDto.getSearchedTotalDiscountRate().getId())))
-                .andExpect(jsonPath("$.products[0].searchedTotalDiscountRate.discountRate", equalTo(dummySearchedProductManagerDto.getSearchedTotalDiscountRate().getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].thumbnailFile.id", equalTo(1)))
-                .andExpect(jsonPath("$.products[0].thumbnailFile.name", equalTo(dummySearchedProductManagerDto.getThumbnailFile().getName())))
-                .andExpect(jsonPath("$.products[0].thumbnailFile.uploadDateTime", equalTo(dummySearchedProductManagerDto.getThumbnailFile().getUploadDateTime().toString())))
-                .andExpect(jsonPath("$.products[0].ebookFile.id", equalTo(2)))
-                .andExpect(jsonPath("$.products[0].ebookFile.name", equalTo(dummySearchedProductManagerDto.getEbookFile().getName())))
-                .andExpect(jsonPath("$.products[0].ebookFile.uploadDateTime", equalTo(dummySearchedProductManagerDto.getEbookFile().getUploadDateTime().toString())))
-                .andExpect(jsonPath("$.products[0].publishedDate", equalTo(dummySearchedProductManagerDto.getPublishedDate().toString())))
-                .andExpect(jsonPath("$.products[0].savingMethod", equalTo(dummySearchedProductManagerDto.getSavingMethod())))
-                .andExpect(jsonPath("$.products[0].categories[0].id", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].categories[0].parent", equalTo(dummySearchedProductManagerDto.getCategories().get(0).getParent())))
-                .andExpect(jsonPath("$.products[0].categories[0].name", equalTo(dummySearchedProductManagerDto.getCategories().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].categories[0].isShown", equalTo(dummySearchedProductManagerDto.getCategories().get(0).getIsShown())))
-                .andExpect(jsonPath("$.products[0].categories[0].disable", equalTo(dummySearchedProductManagerDto.getCategories().get(0).getDisable())))
-                .andExpect(jsonPath("$.products[0].authors[0].id", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].authors[0].name", equalTo(dummySearchedProductManagerDto.getAuthors().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].tags[0].id", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].tags[0].name", equalTo(dummySearchedProductManagerDto.getTags().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].subscribeProducts[0].id", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].subscribeProducts[0].issn", equalTo(dummySearchedProductManagerDto.getSubscribeProducts().get(0).getIssn())))
+                .andExpect(jsonPath("$.data.count", equalTo(INT_ONE)))
+                .andExpect(jsonPath("$.data.products[0].id", equalTo(INT_MIN)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].title",
+                        equalTo(dummySearchedProductManagerDto.getTitle())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isbn",
+                        equalTo(dummySearchedProductManagerDto.getIsbn())
+                ))
+                .andExpect(jsonPath("$.data.products[0].actualPrice", equalTo(1000)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].discountRate",
+                        equalTo(dummySearchedProductManagerDto.getDiscountRate())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].separatelyDiscount",
+                        equalTo(dummySearchedProductManagerDto.isSeparatelyDiscount())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].givenPointRate",
+                        equalTo(dummySearchedProductManagerDto.getGivenPointRate())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isGivenPoint",
+                        equalTo(dummySearchedProductManagerDto.getIsGivenPoint())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isSale",
+                        equalTo(dummySearchedProductManagerDto.getIsSale())
+                ))
+                .andExpect(jsonPath("$.data.products[0].quantity", equalTo(1000)))
+                .andExpect(jsonPath("$.data.products[0].productType.id", equalTo(1)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].productType.name",
+                        equalTo(dummySearchedProductManagerDto.getProductType().getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].searchedTotalDiscountRate.id",
+                        equalTo(dummySearchedProductManagerDto.getSearchedTotalDiscountRate()
+                                .getId())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].searchedTotalDiscountRate.discountRate",
+                        equalTo(dummySearchedProductManagerDto.getSearchedTotalDiscountRate()
+                                .getDiscountRate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].thumbnailFile.id", equalTo(1)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFile.name",
+                        equalTo(dummySearchedProductManagerDto.getThumbnailFile().getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFile.uploadDateTime",
+                        equalTo(dummySearchedProductManagerDto.getThumbnailFile()
+                                .getUploadDateTime()
+                                .toString())
+                ))
+                .andExpect(jsonPath("$.data.products[0].ebookFile.id", equalTo(2)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].ebookFile.name",
+                        equalTo(dummySearchedProductManagerDto.getEbookFile().getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].ebookFile.uploadDateTime",
+                        equalTo(dummySearchedProductManagerDto.getEbookFile()
+                                .getUploadDateTime()
+                                .toString())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publishedDate",
+                        equalTo(dummySearchedProductManagerDto.getPublishedDate().toString())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].savingMethod",
+                        equalTo(dummySearchedProductManagerDto.getSavingMethod())
+                ))
+                .andExpect(jsonPath("$.data.products[0].categories[0].id", equalTo(INT_ONE)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].parent",
+                        equalTo(dummySearchedProductManagerDto.getCategories().get(0).getParent())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].name",
+                        equalTo(dummySearchedProductManagerDto.getCategories().get(0).getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].isShown",
+                        equalTo(dummySearchedProductManagerDto.getCategories().get(0).getIsShown())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].disable",
+                        equalTo(dummySearchedProductManagerDto.getCategories().get(0).getDisable())
+                ))
+                .andExpect(jsonPath("$.data.products[0].authors[0].id", equalTo(INT_ONE)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].authors[0].name",
+                        equalTo(dummySearchedProductManagerDto.getAuthors().get(0).getName())
+                ))
+                .andExpect(jsonPath("$.data.products[0].tags[0].id", equalTo(INT_ONE)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].tags[0].name",
+                        equalTo(dummySearchedProductManagerDto.getTags().get(0).getName())
+                ))
+                .andExpect(jsonPath("$.data.products[0].subscribeProducts[0].id", equalTo(INT_ONE)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].subscribeProducts[0].issn",
+                        equalTo(dummySearchedProductManagerDto.getSubscribeProducts()
+                                .get(0)
+                                .getIssn())
+                ))
                 .andDo(print());
 
-        verify(searchProductService, atLeastOnce()).searchProductsByCategoryId(dummySearchedProductManagerDto.getCategories()
-                .get(0)
-                .getId(), 0, 1);
+        verify(searchProductService, atLeastOnce()).searchProductsByCategoryId(
+                dummySearchedProductManagerDto.getCategories()
+                        .get(0)
+                        .getId(),
+                0,
+                1
+        );
     }
 
     @WithMockUser
@@ -853,40 +1168,117 @@ class SearchProductControllerTest {
 
         //then
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.count", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].id", equalTo(INT_MIN)))
-                .andExpect(jsonPath("$.products[0].title", equalTo(dummySearchedProductManagerDto.getTitle())))
-                .andExpect(jsonPath("$.products[0].isbn", equalTo(dummySearchedProductManagerDto.getIsbn())))
-                .andExpect(jsonPath("$.products[0].actualPrice", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].discountRate", equalTo(dummySearchedProductManagerDto.getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].separatelyDiscount", equalTo(dummySearchedProductManagerDto.isSeparatelyDiscount())))
-                .andExpect(jsonPath("$.products[0].givenPointRate", equalTo(dummySearchedProductManagerDto.getGivenPointRate())))
-                .andExpect(jsonPath("$.products[0].isGivenPoint", equalTo(dummySearchedProductManagerDto.getIsGivenPoint())))
-                .andExpect(jsonPath("$.products[0].isSale", equalTo(dummySearchedProductManagerDto.getIsSale())))
-                .andExpect(jsonPath("$.products[0].quantity", equalTo(1000)))
-                .andExpect(jsonPath("$.products[0].productType.id", equalTo(1)))
-                .andExpect(jsonPath("$.products[0].productType.name", equalTo(dummySearchedProductManagerDto.getProductType().getName())))
-                .andExpect(jsonPath("$.products[0].searchedTotalDiscountRate.id", equalTo(dummySearchedProductManagerDto.getSearchedTotalDiscountRate().getId())))
-                .andExpect(jsonPath("$.products[0].searchedTotalDiscountRate.discountRate", equalTo(dummySearchedProductManagerDto.getSearchedTotalDiscountRate().getDiscountRate())))
-                .andExpect(jsonPath("$.products[0].thumbnailFile.id", equalTo(1)))
-                .andExpect(jsonPath("$.products[0].thumbnailFile.name", equalTo(dummySearchedProductManagerDto.getThumbnailFile().getName())))
-                .andExpect(jsonPath("$.products[0].thumbnailFile.uploadDateTime", equalTo(dummySearchedProductManagerDto.getThumbnailFile().getUploadDateTime().toString())))
-                .andExpect(jsonPath("$.products[0].ebookFile.id", equalTo(2)))
-                .andExpect(jsonPath("$.products[0].ebookFile.name", equalTo(dummySearchedProductManagerDto.getEbookFile().getName())))
-                .andExpect(jsonPath("$.products[0].ebookFile.uploadDateTime", equalTo(dummySearchedProductManagerDto.getEbookFile().getUploadDateTime().toString())))
-                .andExpect(jsonPath("$.products[0].publishedDate", equalTo(dummySearchedProductManagerDto.getPublishedDate().toString())))
-                .andExpect(jsonPath("$.products[0].savingMethod", equalTo(dummySearchedProductManagerDto.getSavingMethod())))
-                .andExpect(jsonPath("$.products[0].categories[0].id", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].categories[0].parent", equalTo(dummySearchedProductManagerDto.getCategories().get(0).getParent())))
-                .andExpect(jsonPath("$.products[0].categories[0].name", equalTo(dummySearchedProductManagerDto.getCategories().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].categories[0].isShown", equalTo(dummySearchedProductManagerDto.getCategories().get(0).getIsShown())))
-                .andExpect(jsonPath("$.products[0].categories[0].disable", equalTo(dummySearchedProductManagerDto.getCategories().get(0).getDisable())))
-                .andExpect(jsonPath("$.products[0].authors[0].id", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].authors[0].name", equalTo(dummySearchedProductManagerDto.getAuthors().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].tags[0].id", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].tags[0].name", equalTo(dummySearchedProductManagerDto.getTags().get(0).getName())))
-                .andExpect(jsonPath("$.products[0].subscribeProducts[0].id", equalTo(INT_ONE)))
-                .andExpect(jsonPath("$.products[0].subscribeProducts[0].issn", equalTo(dummySearchedProductManagerDto.getSubscribeProducts().get(0).getIssn())))
+                .andExpect(jsonPath("$.data.count", equalTo(INT_ONE)))
+                .andExpect(jsonPath("$.data.products[0].id", equalTo(INT_MIN)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].title",
+                        equalTo(dummySearchedProductManagerDto.getTitle())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isbn",
+                        equalTo(dummySearchedProductManagerDto.getIsbn())
+                ))
+                .andExpect(jsonPath("$.data.products[0].actualPrice", equalTo(1000)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].discountRate",
+                        equalTo(dummySearchedProductManagerDto.getDiscountRate())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].separatelyDiscount",
+                        equalTo(dummySearchedProductManagerDto.isSeparatelyDiscount())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].givenPointRate",
+                        equalTo(dummySearchedProductManagerDto.getGivenPointRate())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isGivenPoint",
+                        equalTo(dummySearchedProductManagerDto.getIsGivenPoint())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].isSale",
+                        equalTo(dummySearchedProductManagerDto.getIsSale())
+                ))
+                .andExpect(jsonPath("$.data.products[0].quantity", equalTo(1000)))
+                .andExpect(jsonPath("$.data.products[0].productType.id", equalTo(1)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].productType.name",
+                        equalTo(dummySearchedProductManagerDto.getProductType().getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].searchedTotalDiscountRate.id",
+                        equalTo(dummySearchedProductManagerDto.getSearchedTotalDiscountRate()
+                                .getId())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].searchedTotalDiscountRate.discountRate",
+                        equalTo(dummySearchedProductManagerDto.getSearchedTotalDiscountRate()
+                                .getDiscountRate())
+                ))
+                .andExpect(jsonPath("$.data.products[0].thumbnailFile.id", equalTo(1)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFile.name",
+                        equalTo(dummySearchedProductManagerDto.getThumbnailFile().getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].thumbnailFile.uploadDateTime",
+                        equalTo(dummySearchedProductManagerDto.getThumbnailFile()
+                                .getUploadDateTime()
+                                .toString())
+                ))
+                .andExpect(jsonPath("$.data.products[0].ebookFile.id", equalTo(2)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].ebookFile.name",
+                        equalTo(dummySearchedProductManagerDto.getEbookFile().getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].ebookFile.uploadDateTime",
+                        equalTo(dummySearchedProductManagerDto.getEbookFile()
+                                .getUploadDateTime()
+                                .toString())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].publishedDate",
+                        equalTo(dummySearchedProductManagerDto.getPublishedDate().toString())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].savingMethod",
+                        equalTo(dummySearchedProductManagerDto.getSavingMethod())
+                ))
+                .andExpect(jsonPath("$.data.products[0].categories[0].id", equalTo(INT_ONE)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].parent",
+                        equalTo(dummySearchedProductManagerDto.getCategories().get(0).getParent())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].name",
+                        equalTo(dummySearchedProductManagerDto.getCategories().get(0).getName())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].isShown",
+                        equalTo(dummySearchedProductManagerDto.getCategories().get(0).getIsShown())
+                ))
+                .andExpect(jsonPath(
+                        "$.data.products[0].categories[0].disable",
+                        equalTo(dummySearchedProductManagerDto.getCategories().get(0).getDisable())
+                ))
+                .andExpect(jsonPath("$.data.products[0].authors[0].id", equalTo(INT_ONE)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].authors[0].name",
+                        equalTo(dummySearchedProductManagerDto.getAuthors().get(0).getName())
+                ))
+                .andExpect(jsonPath("$.data.products[0].tags[0].id", equalTo(INT_ONE)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].tags[0].name",
+                        equalTo(dummySearchedProductManagerDto.getTags().get(0).getName())
+                ))
+                .andExpect(jsonPath("$.data.products[0].subscribeProducts[0].id", equalTo(INT_ONE)))
+                .andExpect(jsonPath(
+                        "$.data.products[0].subscribeProducts[0].issn",
+                        equalTo(dummySearchedProductManagerDto.getSubscribeProducts()
+                                .get(0)
+                                .getIssn())
+                ))
                 .andDo(print());
 
         verify(searchProductService, atLeastOnce()).searchProductsByCategoryName(

--- a/src/test/java/shop/yesaladin/shop/product/controller/SearchProductControllerTest.java
+++ b/src/test/java/shop/yesaladin/shop/product/controller/SearchProductControllerTest.java
@@ -72,7 +72,7 @@ class SearchProductControllerTest {
                 .discountRate(10)
                 .sellingPrice(1000L)
                 .authors(List.of("author"))
-                .isForcedOutOfStack(false)
+                .isForcedOutOfStock(false)
                 .thumbnailFileUrl("깃 허브.jpg")
                 .publishedDate(LocalDate.now().toString())
                 .categories(List.of(new SearchedProductCategory(12L, null, "국내소설", true, false)))
@@ -201,7 +201,7 @@ class SearchProductControllerTest {
                 .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
                 .andExpect(jsonPath(
                         "$.data.products[0].isForcedOutOfStack",
-                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStock())
                 ))
                 .andExpect(jsonPath(
                         "$.data.products[0].thumbnailFileUrl",
@@ -332,7 +332,7 @@ class SearchProductControllerTest {
                 .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
                 .andExpect(jsonPath(
                         "$.data.products[0].isForcedOutOfStack",
-                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStock())
                 ))
                 .andExpect(jsonPath(
                         "$.data.products[0].thumbnailFileUrl",
@@ -459,7 +459,7 @@ class SearchProductControllerTest {
                 .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
                 .andExpect(jsonPath(
                         "$.data.products[0].isForcedOutOfStack",
-                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStock())
                 ))
                 .andExpect(jsonPath(
                         "$.data.products[0].thumbnailFileUrl",
@@ -588,7 +588,7 @@ class SearchProductControllerTest {
                 .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
                 .andExpect(jsonPath(
                         "$.data.products[0].isForcedOutOfStack",
-                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStock())
                 ))
                 .andExpect(jsonPath(
                         "$.data.products[0].thumbnailFileUrl",
@@ -721,7 +721,7 @@ class SearchProductControllerTest {
                 .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
                 .andExpect(jsonPath(
                         "$.data.products[0].isForcedOutOfStack",
-                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStock())
                 ))
                 .andExpect(jsonPath(
                         "$.data.products[0].thumbnailFileUrl",
@@ -854,7 +854,7 @@ class SearchProductControllerTest {
                 .andExpect(jsonPath("$.data.products[0].sellingPrice", equalTo(1000)))
                 .andExpect(jsonPath(
                         "$.data.products[0].isForcedOutOfStack",
-                        equalTo(dummySearchedProductDto.getIsForcedOutOfStack())
+                        equalTo(dummySearchedProductDto.getIsForcedOutOfStock())
                 ))
                 .andExpect(jsonPath(
                         "$.data.products[0].thumbnailFileUrl",

--- a/src/test/java/shop/yesaladin/shop/product/service/impl/SearchProductServiceImplTest.java
+++ b/src/test/java/shop/yesaladin/shop/product/service/impl/SearchProductServiceImplTest.java
@@ -43,7 +43,7 @@ class SearchProductServiceImplTest {
                 .discountRate(10)
                 .sellingPrice(1000L)
                 .authors(List.of("author"))
-                .isForcedOutOfStack(false)
+                .isForcedOutOfStock(false)
                 .thumbnailFileUrl("깃 허브.jpg")
                 .publishedDate(LocalDate.now().toString())
                 .categories(List.of(new SearchedProductCategory(12L, null, "국내소설", true, false)))
@@ -343,7 +343,7 @@ class SearchProductServiceImplTest {
                 .getPublishedDate()).isEqualTo(dummySearchedProductDto.getPublishedDate());
         assertThat(result.getProducts()
                 .get(0)
-                .getIsForcedOutOfStack()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStack());
+                .getIsForcedOutOfStock()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStock());
         assertThat(result.getProducts().get(0).getCategories()).hasSameSizeAs(
                 dummySearchedProductDto.getCategories());
         assertThat(result.getProducts()
@@ -430,7 +430,7 @@ class SearchProductServiceImplTest {
                 .getPublishedDate()).isEqualTo(dummySearchedProductDto.getPublishedDate());
         assertThat(result.getProducts()
                 .get(0)
-                .getIsForcedOutOfStack()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStack());
+                .getIsForcedOutOfStock()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStock());
         assertThat(result.getProducts().get(0).getCategories()).hasSameSizeAs(
                 dummySearchedProductDto.getCategories());
         assertThat(result.getProducts()
@@ -518,7 +518,7 @@ class SearchProductServiceImplTest {
                 .getPublishedDate()).isEqualTo(dummySearchedProductDto.getPublishedDate());
         assertThat(result.getProducts()
                 .get(0)
-                .getIsForcedOutOfStack()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStack());
+                .getIsForcedOutOfStock()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStock());
         assertThat(result.getProducts().get(0).getCategories()).hasSameSizeAs(
                 dummySearchedProductDto.getCategories());
         assertThat(result.getProducts()
@@ -605,7 +605,7 @@ class SearchProductServiceImplTest {
                 .getPublishedDate()).isEqualTo(dummySearchedProductDto.getPublishedDate());
         assertThat(result.getProducts()
                 .get(0)
-                .getIsForcedOutOfStack()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStack());
+                .getIsForcedOutOfStock()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStock());
         assertThat(result.getProducts().get(0).getCategories()).hasSameSizeAs(
                 dummySearchedProductDto.getCategories());
         assertThat(result.getProducts()
@@ -692,7 +692,7 @@ class SearchProductServiceImplTest {
                 .getPublishedDate()).isEqualTo(dummySearchedProductDto.getPublishedDate());
         assertThat(result.getProducts()
                 .get(0)
-                .getIsForcedOutOfStack()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStack());
+                .getIsForcedOutOfStock()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStock());
         assertThat(result.getProducts().get(0).getCategories()).hasSameSizeAs(
                 dummySearchedProductDto.getCategories());
         assertThat(result.getProducts()
@@ -779,7 +779,7 @@ class SearchProductServiceImplTest {
                 .getPublishedDate()).isEqualTo(dummySearchedProductDto.getPublishedDate());
         assertThat(result.getProducts()
                 .get(0)
-                .getIsForcedOutOfStack()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStack());
+                .getIsForcedOutOfStock()).isEqualTo(dummySearchedProductDto.getIsForcedOutOfStock());
         assertThat(result.getProducts().get(0).getCategories()).hasSameSizeAs(
                 dummySearchedProductDto.getCategories());
         assertThat(result.getProducts()


### PR DESCRIPTION
1. Controller return 값에 ResponseDto를 적용
2. 상품 검색 조건에 is_deleted가 false일 경우만 검색되게 추가
2-1. TermQuery를 생성하는 구간이 반복되서 리팩토링