### PR TITLE
Docs: member 관련 REST Docs 추가

### DIFF
--- a/src/main/asciidoc/member-api-docs.adoc
+++ b/src/main/asciidoc/member-api-docs.adoc
@@ -1,0 +1,134 @@
+= Member
+
+=== 회원 탈퇴
+
+==== curl
+include::{snippets}/withdraw-member-success/curl-request.adoc[]
+
+==== request
+
+===== Example
+include::{snippets}/withdraw-member-success/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/withdraw-member-success/response-fields.adoc[]
+
+===== Example
+include::{snippets}/withdraw-member-success/http-response.adoc[]
+
+
+=== 회원 탈퇴 실패
+
+==== curl
+include::{snippets}/withdraw-member-fail-member-not-found/curl-request.adoc[]
+
+==== request
+
+===== Example
+include::{snippets}/withdraw-member-fail-member-not-found/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/withdraw-member-fail-member-not-found/response-fields.adoc[]
+
+===== Example
+include::{snippets}/withdraw-member-fail-member-not-found/http-response.adoc[]
+
+
+=== 회원의 loginId 중복 여부 판단
+
+==== curl
+include::{snippets}/existsLoginId/curl-request.adoc[]
+
+==== request
+
+===== Example
+include::{snippets}/existsLoginId/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/existsLoginId/response-fields.adoc[]
+
+===== Example
+include::{snippets}/existsLoginId/response-body.adoc[]
+
+
+=== 회원의 nickname 중복 여부 판단
+
+==== curl
+include::{snippets}/existsNickname/curl-request.adoc[]
+
+==== request
+
+===== Example
+include::{snippets}/existsNickname/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/existsNickname/response-fields.adoc[]
+
+===== Example
+include::{snippets}/existsNickname/response-body.adoc[]
+
+
+=== 회원의 email 중복 여부 판단
+
+==== curl
+include::{snippets}/existsEmail/curl-request.adoc[]
+
+==== request
+
+===== Example
+include::{snippets}/existsEmail/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/existsEmail/response-fields.adoc[]
+
+===== Example
+include::{snippets}/existsEmail/response-body.adoc[]
+
+
+=== 회원의 phone 중복 여부 판단
+
+==== curl
+include::{snippets}/existsPhone/curl-request.adoc[]
+
+==== request
+
+===== Example
+include::{snippets}/existsPhone/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/existsPhone/response-fields.adoc[]
+
+===== Example
+include::{snippets}/existsPhone/response-body.adoc[]
+
+
+=== 회원 통계용 데이터 조회
+
+==== curl
+include::{snippets}/get-member-statistics-success/curl-request.adoc[]
+
+==== request
+
+===== Example
+include::{snippets}/get-member-statistics-success/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/get-member-statistics-success/response-fields.adoc[]
+
+===== Example
+include::{snippets}/get-member-statistics-success/response-body.adoc[]
+

--- a/src/main/asciidoc/member-login-api-docs.adoc
+++ b/src/main/asciidoc/member-login-api-docs.adoc
@@ -1,0 +1,19 @@
+= 인증 서버 용 member 조회
+
+=== loginId 기준 member 조회
+
+==== curl
+include::{snippets}/doLogin/curl-request.adoc[]
+
+==== request
+
+===== Example
+include::{snippets}/doLogin/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/doLogin/response-fields.adoc[]
+
+===== Example
+include::{snippets}/doLogin/http-response.adoc[]

--- a/src/main/asciidoc/member-signup-api-docs.adoc
+++ b/src/main/asciidoc/member-signup-api-docs.adoc
@@ -1,0 +1,44 @@
+= Member Signup
+
+=== 일반 회원 가입
+
+==== curl
+include::{snippets}/register-member-success/curl-request.adoc[]
+
+==== request
+
+===== Body
+
+include::{snippets}/register-member-success/request-fields.adoc[]
+
+===== Example
+include::{snippets}/register-member-success/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/register-member-success/response-fields.adoc[]
+
+===== Example
+include::{snippets}/register-member-success/http-response.adoc[]
+
+=== OAuth2 회원 가입
+
+==== curl
+include::{snippets}/register-oauth2-member-success/curl-request.adoc[]
+
+==== request
+
+===== Body
+include::{snippets}/register-oauth2-member-success/request-fields.adoc[]
+
+===== Example
+include::{snippets}/register-oauth2-member-success/http-request.adoc[]
+
+==== response
+
+===== Body
+include::{snippets}/register-oauth2-member-success/response-fields.adoc[]
+
+===== Example
+include::{snippets}/register-oauth2-member-success/http-response.adoc[]

--- a/src/main/java/shop/yesaladin/shop/member/service/impl/QueryMemberServiceImpl.java
+++ b/src/main/java/shop/yesaladin/shop/member/service/impl/QueryMemberServiceImpl.java
@@ -126,31 +126,6 @@ public class QueryMemberServiceImpl implements QueryMemberService {
      */
     @Transactional(readOnly = true)
     @Override
-    public MemberLoginResponseDto findMemberLoginInfoByEmail(String email) {
-        Member member = queryMemberRepository.findMemberByEmail(email)
-                .orElseThrow(() -> new ClientException(
-                        ErrorCode.MEMBER_NOT_FOUND,
-                        "Member email: " + email
-                ));
-
-        List<String> roles = queryMemberRoleRepository.findMemberRolesByMemberId(member.getId());
-
-        return new MemberLoginResponseDto(
-                member.getId(),
-                member.getName(),
-                member.getNickname(),
-                member.getLoginId(),
-                member.getEmail(),
-                member.getPassword(),
-                roles
-        );
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Transactional(readOnly = true)
-    @Override
     public Page<MemberManagerResponseDto> findMemberManagesByLoginId(
             String loginId,
             Pageable pageable

--- a/src/main/java/shop/yesaladin/shop/member/service/inter/QueryMemberService.java
+++ b/src/main/java/shop/yesaladin/shop/member/service/inter/QueryMemberService.java
@@ -80,16 +80,6 @@ public interface QueryMemberService {
     MemberLoginResponseDto findMemberLoginInfoByLoginId(String loginId);
 
     /**
-     * OAuth2 로그인 시 이미 자사 회원인 경우 해당 회원 정보를 조회 하기 위한 메서드 입니다.
-     *
-     * @param email member의 email
-     * @return login 대상의 유저 정보와 권한 정보를 담은 DTO
-     * @author 송학현
-     * @since 1.0
-     */
-    MemberLoginResponseDto findMemberLoginInfoByEmail(String email);
-
-    /**
      * 관리자의 회원 관리 요창에 대해 회원을 unique column 인 LoginId 를 기준으로 조회하는 메서드 이다.
      *
      * @param loginId member의 loginId

--- a/src/test/java/shop/yesaladin/shop/member/controller/QueryMemberLoginControllerTest.java
+++ b/src/test/java/shop/yesaladin/shop/member/controller/QueryMemberLoginControllerTest.java
@@ -17,16 +17,16 @@ import static shop.yesaladin.shop.docs.ApiDocumentUtils.getDocumentResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import shop.yesaladin.common.code.ErrorCode;
@@ -35,6 +35,7 @@ import shop.yesaladin.shop.member.dto.MemberLoginResponseDto;
 import shop.yesaladin.shop.member.service.inter.QueryMemberService;
 
 @AutoConfigureRestDocs
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(QueryMemberLoginController.class)
 class QueryMemberLoginControllerTest {
 
@@ -47,7 +48,7 @@ class QueryMemberLoginControllerTest {
     @MockBean
     QueryMemberService queryMemberService;
 
-    @WithMockUser
+    @WithAnonymousUser
     @Test
     void doLogin_failed_whenMemberNotFound() throws Exception {
         //given
@@ -64,7 +65,7 @@ class QueryMemberLoginControllerTest {
         verify(queryMemberService, times(1)).findMemberLoginInfoByLoginId(loginId);
     }
 
-    @WithMockUser
+    @WithAnonymousUser
     @Test
     void doLogin() throws Exception {
         //given
@@ -111,102 +112,6 @@ class QueryMemberLoginControllerTest {
                 getDocumentResponse(),
                 pathParameters(
                         parameterWithName("loginId").description("회원의 Login ID")
-                ),
-                responseFields(
-                        fieldWithPath("success").type(JsonFieldType.BOOLEAN)
-                                .description("동작 성공 여부"),
-                        fieldWithPath("data.id").type(JsonFieldType.NUMBER)
-                                .description("회원의 PK"),
-                        fieldWithPath("data.name").type(JsonFieldType.STRING)
-                                .description("회원의 이름"),
-                        fieldWithPath("data.nickname").type(JsonFieldType.STRING)
-                                .description("회원의 닉네임"),
-                        fieldWithPath("data.loginId").type(JsonFieldType.STRING)
-                                .description("회원의 loginId"),
-                        fieldWithPath("data.email").type(JsonFieldType.STRING)
-                                .description("회원의 email"),
-                        fieldWithPath("data.password").type(JsonFieldType.STRING)
-                                .description("회원의 password"),
-                        fieldWithPath("data.roles").type(JsonFieldType.ARRAY)
-                                .description("회원의 권한 리스트"),
-                        fieldWithPath("status").type(JsonFieldType.NUMBER)
-                                .description("HTTP 상태 코드"),
-                        fieldWithPath("errorMessages").type(JsonFieldType.ARRAY)
-                                .description("에러 메시지")
-                                .optional()
-                )
-        ));
-    }
-
-    @Disabled
-    @WithMockUser
-    @Test
-    void getMemberByEmail_failed_whenMemberNotFound() throws Exception {
-        //given
-        String email = "test@test.com";
-
-        //when
-        Mockito.when(queryMemberService.findMemberLoginInfoByEmail(email))
-                .thenThrow(new ClientException(ErrorCode.MEMBER_NOT_FOUND, ""));
-
-        //then
-        mockMvc.perform(get("/v1/members/oauth2/login/{email}", email))
-                .andExpect(status().is4xxClientError());
-
-        verify(queryMemberService, times(0)).findMemberLoginInfoByEmail(email);
-    }
-
-    @Disabled
-    @WithMockUser(username = "testId", authorities = {"ROLE_MEMBER", "ROLE_ADMIN"})
-    @Test
-    void getMemberByEmail() throws Exception {
-        //given
-        Long memberId = 1L;
-        String memberName = "testName";
-        String memberNickname = "testNickname";
-        String loginId = "testId";
-        String email = "test@test.com";
-        String password = "testPassword";
-        List<String> roles = List.of("ROLE_MEMBER", "ROLE_ADMIN");
-
-        MemberLoginResponseDto response = new MemberLoginResponseDto(
-                memberId,
-                memberName,
-                memberNickname,
-                loginId,
-                email,
-                password,
-                roles
-        );
-
-        //when
-        Mockito.when(queryMemberService.findMemberLoginInfoByEmail(email))
-                .thenReturn(response);
-
-        //then
-        ResultActions resultActions = mockMvc.perform(get(
-                        "/v1/members/oauth2/login/{email}",
-                        email
-                ))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.data.id", equalTo(memberId.intValue())))
-                .andExpect(jsonPath("$.data.name", equalTo(memberName)))
-                .andExpect(jsonPath("$.data.nickname", equalTo(memberNickname)))
-                .andExpect(jsonPath("$.data.loginId", equalTo(loginId)))
-                .andExpect(jsonPath("$.data.email", equalTo(email)))
-                .andExpect(jsonPath("$.data.password", equalTo(password)))
-                .andExpect(jsonPath("$.data.roles", equalTo(roles)));
-
-        verify(queryMemberService, times(1)).findMemberLoginInfoByEmail(email);
-
-        //docs
-        resultActions.andDo(document(
-                "doLogin",
-                getDocumentRequest(),
-                getDocumentResponse(),
-                pathParameters(
-                        parameterWithName("email").description("회원의 Email")
                 ),
                 responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN)

--- a/src/test/java/shop/yesaladin/shop/member/service/impl/QueryMemberServiceImplTest.java
+++ b/src/test/java/shop/yesaladin/shop/member/service/impl/QueryMemberServiceImplTest.java
@@ -172,43 +172,6 @@ class QueryMemberServiceImplTest {
     }
 
     @Test
-    void findMemberLoginInfoByEmail_failed_whenMemberNotFound() throws Exception {
-        //given
-        String email = "test@test.com";
-
-        Mockito.when(queryMemberRepository.findMemberByEmail(email))
-                .thenReturn(Optional.empty());
-
-        //when, then
-        assertThatThrownBy(() -> service.findMemberLoginInfoByEmail(email))
-                .isInstanceOf(ClientException.class);
-    }
-
-    @Test
-    void findMemberLoginInfoByEmail() throws Exception {
-        //given
-        String email = "test@test.com";
-        Long memberId = 1L;
-
-        Mockito.when(queryMemberRepository.findMemberByEmail(email))
-                .thenReturn(Optional.of(expectedMember));
-        Mockito.when(expectedMember.getLoginId()).thenReturn(email);
-        Mockito.when(expectedMember.getId()).thenReturn(memberId);
-
-        Mockito.when(queryMemberRoleRepository.findMemberRolesByMemberId(memberId))
-                .thenReturn(List.of("ROLE_MEMBER"));
-
-        //when
-        MemberLoginResponseDto response = service.findMemberLoginInfoByEmail(
-                email);
-
-        //then
-        assertThat(response.getRoles()).hasSize(1);
-        assertThat(response.getLoginId()).isEqualTo(email);
-        assertThat(response.getId()).isEqualTo(memberId);
-    }
-
-    @Test
     void findMemberManagesByLoginId() {
         //given
         String loginId = "loginId";


### PR DESCRIPTION
Member 관련 REST Docs를 추가합니다.
- 회원 가입(일반 회원, OAuth2 회원)
- 회원 탈퇴
- 인증 서버용 회원 조회(loginId 기준)
- 회원 가입 시 중복 체크(loginId, nickname, phone, email)
- 관리자용 회원 통계 데이터 조회